### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.5.0"
 description = "A gateway for redirecting authentic signed URLs to the requested API"
 license = "AGPL-3.0-only"
 edition = "2021"
+repository = "https://github.com/gabotechs/signway"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.